### PR TITLE
(feat) Allow empty API key

### DIFF
--- a/src/Facades/Pdf.php
+++ b/src/Facades/Pdf.php
@@ -24,7 +24,7 @@ class Pdf extends Facade
      *
      * @throws InvalidCredentialsException
      */
-    public static function using(string $apiUrl, string $apiKey): PdfService
+    public static function using(string $apiUrl, string $apiKey = ''): PdfService
     {
         return PdfService::make($apiUrl, $apiKey);
     }

--- a/src/PdfService.php
+++ b/src/PdfService.php
@@ -28,6 +28,8 @@ use ValueError;
 
 class PdfService
 {
+    protected readonly string $apiKey;
+
     protected bool $landscape = false;
 
     /** @var array{0: float, 1: float} */
@@ -60,11 +62,13 @@ class PdfService
      */
     public function __construct(
         protected readonly string $apiUrl,
-        protected readonly string $apiKey,
+        string $apiKey = '',
     ) {
-        if (empty($this->apiKey) || empty($this->apiUrl)) {
-            throw new InvalidCredentialsException('Cannot instantiate PdfService without an API Key and API URL');
+        if (empty($this->apiUrl)) {
+            throw new InvalidCredentialsException('Cannot instantiate PdfService without an API URL');
         }
+
+        $this->apiKey = $apiKey;
 
         $this->size = Format::A4->dimensions();
     }
@@ -77,11 +81,13 @@ class PdfService
      */
     public static function make(?string $apiUrl = null, ?string $apiKey = null): self
     {
-        $apiKeyToUse = $apiKey ?? config('pdfservice.key', '');
         $apiUrlToUse = $apiUrl ?? config('pdfservice.url', '');
 
-        if (! is_string($apiKeyToUse) || ! is_string($apiUrlToUse)) {
-            throw new InvalidCredentialsException('Cannot instantiate PdfService without an API Key and API URL');
+        $configKey = config('pdfservice.key', '');
+        $apiKeyToUse = $apiKey ?? (is_string($configKey) ? $configKey : '');
+
+        if (! is_string($apiUrlToUse)) {
+            throw new InvalidCredentialsException('Cannot instantiate PdfService without an API URL');
         }
 
         return new self($apiUrlToUse, $apiKeyToUse);
@@ -369,9 +375,11 @@ class PdfService
     {
         $stack = HandlerStack::create();
 
-        $stack->push(Middleware::mapRequest(
-            fn (RequestInterface $request) => $request->withHeader('X-Api-Key', $this->apiKey)
-        ));
+        if (! empty($this->apiKey)) {
+            $stack->push(Middleware::mapRequest(
+                fn (RequestInterface $request) => $request->withHeader('X-Api-Key', $this->apiKey)
+            ));
+        }
 
         return new Client(['handler' => $stack]);
     }

--- a/tests/Unit/PdfServiceTest.php
+++ b/tests/Unit/PdfServiceTest.php
@@ -35,18 +35,29 @@ it('throws exception when url is empty', function () {
     new PdfService('', 'my-api-key');
 })->throws(
     InvalidCredentialsException::class,
-    'Cannot instantiate PdfService without an API Key and API URL'
+    'Cannot instantiate PdfService without an API URL'
 );
 
-it('throws exception when key is empty', function () {
-    new PdfService('https://example.com', '');
-})->throws(
-    InvalidCredentialsException::class,
-    'Cannot instantiate PdfService without an API Key and API URL'
-);
+it('can be instantiated with only url (no api key)', function () {
+    $service = new PdfService('https://example.com');
+
+    expect($service)->toBeInstanceOf(PdfService::class);
+});
+
+it('can be instantiated with empty api key', function () {
+    $service = new PdfService('https://example.com', '');
+
+    expect($service)->toBeInstanceOf(PdfService::class);
+});
 
 it('can be created via make() with explicit params', function () {
     $service = PdfService::make('https://custom.url', 'custom-key');
+
+    expect($service)->toBeInstanceOf(PdfService::class);
+});
+
+it('can be created via make() with only url param', function () {
+    $service = PdfService::make('https://example.com');
 
     expect($service)->toBeInstanceOf(PdfService::class);
 });
@@ -60,6 +71,15 @@ it('can be created via make() with config fallback', function () {
     expect($service)->toBeInstanceOf(PdfService::class);
 });
 
+it('can be created via make() when config has url but no key', function () {
+    config(['pdfservice.url' => 'https://config.url']);
+    config(['pdfservice.key' => null]);
+
+    $service = PdfService::make();
+
+    expect($service)->toBeInstanceOf(PdfService::class);
+});
+
 it('throws exception when config returns non-string values', function () {
     config(['pdfservice.url' => null]);
     config(['pdfservice.key' => 123]);
@@ -67,7 +87,7 @@ it('throws exception when config returns non-string values', function () {
     PdfService::make();
 })->throws(
     InvalidCredentialsException::class,
-    'Cannot instantiate PdfService without an API Key and API URL'
+    'Cannot instantiate PdfService without an API URL'
 );
 
 it('sets format using Format enum', function () {


### PR DESCRIPTION
- [x] Updated PdfService to allow use without an API key. This is useful where Gotenberg server is directly used without any proxy mandating API Key auth.
- [x] Updated tests
